### PR TITLE
Optional generic types for `Payload`

### DIFF
--- a/algorithm.ts
+++ b/algorithm.ts
@@ -17,8 +17,8 @@ export type Algorithm =
   | "RS512"
   | "ES256"
   | "ES384"
-  // | "ES512" //is not yet supported.
   // https://github.com/denoland/deno/blob/main/ext/crypto/00_crypto.js
+  // | "ES512" //is not yet supported.
   | "none";
 
 // Still needs an 'any' type! Does anyone have an idea?

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export * as base64url from "https://deno.land/std@0.204.0/encoding/base64url.ts";
+export * as base64url from "https://deno.land/std@0.205.0/encoding/base64url.ts";

--- a/dist/mod.js
+++ b/dist/mod.js
@@ -396,12 +396,16 @@ function createSigningInput(header, payload) {
     return `${mod.encode(encoder1.encode(JSON.stringify(header)))}.${mod.encode(encoder1.encode(JSON.stringify(payload)))}`;
 }
 async function create1(header, payload, key) {
-    if (verify(header.alg, key)) {
-        const signingInput = createSigningInput(header, payload);
-        const signature = await create(header.alg, key, signingInput);
-        return `${signingInput}.${signature}`;
+    if (isObject(payload)) {
+        if (verify(header.alg, key)) {
+            const signingInput = createSigningInput(header, payload);
+            const signature = await create(header.alg, key, signingInput);
+            return `${signingInput}.${signature}`;
+        } else {
+            throw new Error(`The jwt's alg '${header.alg}' does not match the key's algorithm.`);
+        }
     } else {
-        throw new Error(`The jwt's alg '${header.alg}' does not match the key's algorithm.`);
+        throw new Error(`The jwt claims set is not a JSON object.`);
     }
 }
 function getNumericDate(exp) {

--- a/examples/deps.ts
+++ b/examples/deps.ts
@@ -1,2 +1,1 @@
-export { serve } from "https://deno.land/std@0.140.0/http/server.ts";
-export * as base64 from "https://deno.land/std@0.140.0/encoding/base64.ts";
+export * as base64 from "https://deno.land/std@0.205.0/encoding/base64.ts";

--- a/examples/hs512.ts
+++ b/examples/hs512.ts
@@ -1,7 +1,10 @@
-import { create, getNumericDate, verify } from "../mod.ts";
-import { serve } from "./deps.ts";
-
-import type { Header, Payload } from "../mod.ts";
+import {
+  create,
+  getNumericDate,
+  type Header,
+  type Payload,
+  verify,
+} from "../mod.ts";
 
 const key = await crypto.subtle.generateKey(
   { name: "HMAC", hash: "SHA-512" },
@@ -31,4 +34,4 @@ async function handleRequest(request: Request) {
   }
 }
 
-await serve(handleRequest);
+Deno.serve(handleRequest);

--- a/examples/rs384.ts
+++ b/examples/rs384.ts
@@ -1,7 +1,4 @@
-import { create, verify } from "../mod.ts";
-import { serve } from "./deps.ts";
-
-import type { Header, Payload } from "../mod.ts";
+import { create, type Header, type Payload, verify } from "../mod.ts";
 
 const { privateKey, publicKey } = await window.crypto.subtle.generateKey(
   {
@@ -39,4 +36,4 @@ async function handleRequest(request: Request) {
   }
 }
 
-await serve(handleRequest);
+Deno.serve(handleRequest);

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -174,6 +174,13 @@ Deno.test({
       Error,
       "The jwt's alg 'HS256' does not match the key's algorithm.",
     );
+    await assertRejects(
+      async () => {
+        await create(header, "invalid payload" as unknown as Payload, keyHS512);
+      },
+      Error,
+      "The jwt claims set is not a JSON object.",
+    );
   },
 });
 
@@ -220,6 +227,19 @@ Deno.test({
         { ignoreExp: true },
       ),
       { exp: 0 },
+    );
+
+    await assertEquals(
+      (await verify<{ email: string }>(
+        await create(
+          { alg: "HS512", typ: "JWT" },
+          { email: "joe@example.com" },
+          keyHS512,
+        ),
+        keyHS512,
+        { ignoreExp: true },
+      )).email,
+      "joe@example.com",
     );
 
     await assertEquals(

--- a/tests/test_deps.ts
+++ b/tests/test_deps.ts
@@ -2,8 +2,8 @@ export {
   assertEquals,
   assertRejects,
   assertThrows,
-} from "https://deno.land/std@0.204.0/testing/asserts.ts";
+} from "https://deno.land/std@0.205.0/testing/asserts.ts";
 
 export {
   decode as decodeHex,
-} from "https://deno.land/std@0.204.0/encoding/hex.ts";
+} from "https://deno.land/std@0.205.0/encoding/hex.ts";


### PR DESCRIPTION
- Add optional generic `Payload` types for `verify` and `decode`.
- Check payload for being an object in `create` for JS.
- Update examples.