### PR TITLE
Publish to JSR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish package
+        run: npx jsr publish

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 .*
 !/.gitignore
+
+!/.github
+/.github/*
+!/.github/workflows
+/.github/workflows/*
+!/.github/workflows/publish.yml
+
 deno.lock

--- a/deno.json
+++ b/deno.json
@@ -1,4 +1,7 @@
 {
+  "name": "@zaubrik/djwt",
+  "version": "3.0.0",
+  "exports": "./mod.ts",
   "tasks": {
     "test": "deno test --check --unstable --allow-all"
   },

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
 export {
   decodeBase64Url,
   encodeBase64Url,
-} from "https://deno.land/std@0.221.0/encoding/base64url.ts";
+} from "jsr:@std/encoding@0.224.0/base64url";


### PR DESCRIPTION
This PR adds a Github workflow to publish to JSR.

Assumed that the scope will be `@zaubrik/djwt` on JSR registry. Please update it (in `deno.json`) if it will be something else and update the version as `3.0.2` after the initial test.

To complete the task, `@zaubrik/djwt` should be created on [jsr.io](https://jsr.io/) and linked to this repository.