### PR TITLE
Import from JSR

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
 export {
   decodeBase64Url,
   encodeBase64Url,
-} from "jsr:@std/encoding@0.224.0/base64url";
+} from "jsr:@std/encoding@1.0.1/base64url";

--- a/examples/deps.ts
+++ b/examples/deps.ts
@@ -1,4 +1,4 @@
 export {
   decodeBase64Url,
   encodeBase64Url,
-} from "https://deno.land/std@0.221.0/encoding/base64url.ts";
+} from "jsr:@std/encoding@1.0.1/base64url";

--- a/tests/test_deps.ts
+++ b/tests/test_deps.ts
@@ -2,6 +2,6 @@ export {
   assertEquals,
   assertRejects,
   assertThrows,
-} from "https://deno.land/std@0.221.0/testing/asserts.ts";
+} from "jsr:@std/testing@0.221.0/asserts";
 
-export { decodeHex } from "https://deno.land/std@0.221.0/encoding/hex.ts";
+export { decodeHex } from "jsr:@std/encoding@1.0.1/hex";


### PR DESCRIPTION
This PR:

- Updates `@std/encoding`'s version tag.
  JSR supports `0.224.0` as tag to be backward compatible but new tag is started from `1.0.0` and the current one is `1.0.1`.

- Imports packages from JSR in tests.

- Imports packages from JSR in examples.

See
- https://jsr.io/@std/encoding
- https://jsr.io/@std/testing